### PR TITLE
Updates readme to fix install path

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # sublime-rufo
 
-Package for sublime text 2/3 which integrates with [rufo](https://github.com/asterite/rufo) for
+Package for sublime text 2/3 which integrates with [rufo](https://github.com/ruby-formatter/rufo) for
 automatic code formatting of Ruby code.
 
 ## Installation
@@ -9,8 +9,8 @@ __Note__: You need to have [Package Control](https://sublime.wbond.net/installat
 
 * Open Command Palette (Ctrl+Shift+P)
 * Select `Package Control: Add Repository`
-* Paste `https://github.com/asterite/sublime-rufo` and hit enter
+* Paste `https://github.com/ruby-formatter/sublime-rufo` and hit enter
 * Open Command Palette once again and select `Install Package`
 * Select `sublime-rufo`
 
-**You also need to install [rufo](https://github.com/asterite/rufo)**
+**You also need to install [rufo](https://github.com/ruby-formatter/rufo)**


### PR DESCRIPTION
Because github paths moved from `/asterite/` to `/ruby-formatter/`