### PR TITLE
Update exitcode

### DIFF
--- a/rufo_format.py
+++ b/rufo_format.py
@@ -41,7 +41,7 @@ class RufoFormatCommand(sublime_plugin.TextCommand):
       exit = proc.wait()
 
     pos = 0
-    if exit == 0:
+    if exit == 3:
       if not self.has_redo():
         for op, text in diff_match_patch().diff_main(src, output):
           if op == diff_match_patch.DIFF_DELETE:


### PR DESCRIPTION
The current version of rufo exits with code 3 if the file has changed. ([spec](https://github.com/ruby-formatter/rufo/blob/a0e54539375ed13b925efd7df7dc403f01630315/spec/lib/rufo/command_spec.rb))